### PR TITLE
Added fp_path_length field to ART

### DIFF
--- a/ART.h
+++ b/ART.h
@@ -37,6 +37,7 @@ namespace ART {
             ArtNode* root;  // pointer to root node
             ArtNode* fp; // fast path
             std::array<ArtNode*, maxPrefixLength> fp_path; // fp path
+            size_t fp_path_length; // stores real length of fp path
             ArtNode* fp_leaf; 
 
             //constructor


### PR DESCRIPTION
- Updated file: _ART.h_ 
- Since we switched from std::vector to stc::array, we need a "size_t fp_path_length" field to the ART class to store the accurate length of fp_path.